### PR TITLE
feat(games): add Sweep of the Realm to game gallery

### DIFF
--- a/src/react-app/components/main-content/GameGallery.js
+++ b/src/react-app/components/main-content/GameGallery.js
@@ -8,6 +8,18 @@ import { mixpanel } from "../../../App";
 
 const games = [
   {
+    title: "Sweep of the Realm",
+    thumbnail:
+      "https://img.itch.zone/aW1nLzI2OTEwODI0LnBuZw==/315x250%23c/e%2BbTWT.png",
+    url: "https://dpsguzzler.itch.io/sweep-of-the-realm",
+    embedUrl: "https://itch.io/embed-upload/17309145?color=333333",
+    description:
+      "A Roomba falls through a portal into a filthy medieval kingdom. The king calls it a curse. You call it a cleaning job.",
+    technologies: "Unity",
+    releaseDate: "April 2026",
+    embeddable: true,
+  },
+  {
     title: "Zen Garden",
     thumbnail:
       "https://img.itch.zone/aW1nLzE3Nzg1NTEzLnBuZw==/315x250%23c/ilHY7P.png",


### PR DESCRIPTION
## Summary
- Adds *Sweep of the Realm* as the newest entry in the game gallery carousel
- Links to https://dpsguzzler.itch.io/sweep-of-the-realm with in-page embed support (embed ID `17309145`)

## Test plan
- [ ] Game card appears first in the carousel
- [ ] Clicking on desktop opens the in-page iframe modal
- [ ] Clicking on mobile opens itch.io in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)