### PR TITLE
Add writing section with The Immigrant's Dilemma

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "start": "react-scripts --openssl-legacy-provider start",
-    "build": "react-scripts --openssl-legacy-provider build",
+    "build": "react-scripts --openssl-legacy-provider build && node scripts/prerender-blog.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint ./src"

--- a/public/index.html
+++ b/public/index.html
@@ -45,6 +45,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:ital,wght@1,900&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Source+Serif+Pro:ital,wght@0,400;0,600;0,700;1,400&display=swap" rel="stylesheet">
     <script src="https://kit.fontawesome.com/70e2a5299a.js" crossorigin="anonymous"></script>
     <script src="https://use.typekit.net/bkt6ydm.js"></script>
     <script>try{Typekit.load({ async: true });}catch(e){}</script>

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,17 @@
       name="description"
       content="Sharang Pai is an AI engineer and product builder at Luma AI whose portfolio connects agentic systems, social-impact technology, open-source work, and game experiments."
     />
+    <link rel="canonical" href="https://sharangpai.me/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Sharang Pai" />
+    <meta property="og:title" content="Sharang Pai | AI Engineer, Product Builder, Game Creator" />
+    <meta property="og:description" content="Sharang Pai is an AI engineer and product builder at Luma AI whose portfolio connects agentic systems, social-impact technology, open-source work, and game experiments." />
+    <meta property="og:url" content="https://sharangpai.me/" />
+    <meta property="og:image" content="https://sharangpai.me/static/favicon/android-icon-192x192.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Sharang Pai | AI Engineer, Product Builder, Game Creator" />
+    <meta name="twitter:description" content="Sharang Pai is an AI engineer and product builder at Luma AI whose portfolio connects agentic systems, social-impact technology, open-source work, and game experiments." />
+    <meta name="twitter:image" content="https://sharangpai.me/static/favicon/android-icon-192x192.png" />
     <link rel="preload" as="image" href="https://sharangpai.me/static/media/portrait.4f21b58b.png">
     <link rel="apple-touch-icon" sizes="57x57" href="%PUBLIC_URL%/static/favicon/apple-icon-57x57.png">
     <link rel="apple-touch-icon" sizes="60x60" href="%PUBLIC_URL%/static/favicon/apple-icon-60x60.png">

--- a/scripts/prerender-blog.js
+++ b/scripts/prerender-blog.js
@@ -1,0 +1,126 @@
+/* eslint-disable no-console */
+/**
+ * Generates per-route static HTML stubs in build/ so social crawlers
+ * (LinkedIn, WhatsApp, Twitter, Facebook, iMessage) get correct OG /
+ * Twitter Card meta tags when /blog or /blog/<slug> URLs are shared.
+ *
+ * How it works:
+ *   1. CRA writes build/index.html (the SPA shell with bundled scripts).
+ *   2. This script copies that shell to build/blog/index.html and
+ *      build/blog/<slug>/index.html for each post, swapping in
+ *      route-specific <title>, description, og:* and twitter:* tags.
+ *   3. Firebase Hosting serves matching static files BEFORE applying the
+ *      SPA rewrite, so a crawler hitting /blog/the-immigrants-dilemma/
+ *      reads the correct meta tags. Real visitors get the same shell, the
+ *      React bundle hydrates, and the SPA renders the post normally.
+ *
+ * Posts are listed inline because the runtime files are ES modules and
+ * this script is plain Node. Add a new entry here whenever you add a
+ * post under src/react-app/components/blog/posts/.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const SITE_URL = "https://sharangpai.me";
+const SITE_TITLE = "Sharang Pai";
+const DEFAULT_OG_IMAGE = `${SITE_URL}/static/favicon/android-icon-192x192.png`;
+
+const buildDir = path.resolve(__dirname, "..", "build");
+const indexPath = path.join(buildDir, "index.html");
+
+if (!fs.existsSync(indexPath)) {
+  console.error(
+    `prerender: ${indexPath} not found — run "npm run build" first.`
+  );
+  process.exit(1);
+}
+
+const baseHtml = fs.readFileSync(indexPath, "utf8");
+
+const posts = [
+  {
+    slug: "the-immigrants-dilemma",
+    title: "The Immigrant's Dilemma",
+    excerpt:
+      "What makes sense for an individual and what might be good for the world are not always the same thing. And increasingly, in a world being shaped by AI, they feel pulled in different directions.",
+    date: "2026-04-26",
+  },
+];
+
+const escapeAttr = (value) =>
+  String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+
+const buildMeta = ({
+  title,
+  description,
+  url,
+  type = "website",
+  publishedTime,
+  image = DEFAULT_OG_IMAGE,
+}) => {
+  const lines = [
+    `    <title>${escapeAttr(title)}</title>`,
+    `    <meta name="description" content="${escapeAttr(description)}" />`,
+    `    <link rel="canonical" href="${escapeAttr(url)}" />`,
+    `    <meta property="og:type" content="${escapeAttr(type)}" />`,
+    `    <meta property="og:site_name" content="${escapeAttr(SITE_TITLE)}" />`,
+    `    <meta property="og:title" content="${escapeAttr(title)}" />`,
+    `    <meta property="og:description" content="${escapeAttr(description)}" />`,
+    `    <meta property="og:url" content="${escapeAttr(url)}" />`,
+    `    <meta property="og:image" content="${escapeAttr(image)}" />`,
+  ];
+  if (publishedTime) {
+    lines.push(
+      `    <meta property="article:published_time" content="${escapeAttr(publishedTime)}" />`
+    );
+  }
+  lines.push(
+    `    <meta name="twitter:card" content="summary_large_image" />`,
+    `    <meta name="twitter:title" content="${escapeAttr(title)}" />`,
+    `    <meta name="twitter:description" content="${escapeAttr(description)}" />`,
+    `    <meta name="twitter:image" content="${escapeAttr(image)}" />`
+  );
+  return lines.join("\n");
+};
+
+const inject = (html, meta) => {
+  const stripped = html.replace(/<title>[^<]*<\/title>/i, "");
+  return stripped.replace("</head>", `${meta}\n  </head>`);
+};
+
+const writeStub = (segments, meta) => {
+  const dir = path.join(buildDir, ...segments);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "index.html"), inject(baseHtml, meta));
+  console.log(`prerender: /${segments.join("/")}/index.html`);
+};
+
+writeStub(
+  ["blog"],
+  buildMeta({
+    title: `Writing — ${SITE_TITLE}`,
+    description:
+      "Long-form notes on AI, products, and the systems they sit inside.",
+    url: `${SITE_URL}/blog`,
+  })
+);
+
+for (const post of posts) {
+  writeStub(
+    ["blog", post.slug],
+    buildMeta({
+      title: `${post.title} — ${SITE_TITLE}`,
+      description: post.excerpt,
+      url: `${SITE_URL}/blog/${post.slug}`,
+      type: "article",
+      publishedTime: post.date,
+    })
+  );
+}
+
+console.log(`prerender: done (${posts.length + 1} stub${posts.length === 0 ? "" : "s"}).`);

--- a/src/react-app/components/MainContent.js
+++ b/src/react-app/components/MainContent.js
@@ -3,6 +3,8 @@ import { Row } from "antd";
 import { Route, Switch } from "react-router-dom";
 
 import BaseContent from "../components/main-content/BaseContent";
+import BlogList from "../components/blog/BlogList";
+import BlogPost from "../components/blog/BlogPost";
 import PageNotFound from "../components/common/error-pages/PageNotFound";
 
 function MainContent() {
@@ -11,7 +13,9 @@ function MainContent() {
       render={({ location }) => (
         <Row className="display-block">
           <Switch location={location}>
-            <Route path="/" component={BaseContent} key="base" />
+            <Route path="/blog/:slug" component={BlogPost} key="blogPost" />
+            <Route path="/blog" exact component={BlogList} key="blogList" />
+            <Route path="/" exact component={BaseContent} key="base" />
             <Route render={() => <PageNotFound />} key="notFound" />
           </Switch>
         </Row>

--- a/src/react-app/components/blog/Blog.css
+++ b/src/react-app/components/blog/Blog.css
@@ -1,0 +1,383 @@
+/*
+ * Blog styling. Inherits the design tokens from BaseContent.css. Variables
+ * are redeclared here so the blog routes look correct even when the home
+ * page hasn't mounted in the same session. Intentionally restrained — no
+ * gradients, no frosted glass, no radial glows.
+ */
+
+:root {
+  --primary: #58c7ff;
+  --primary-hover: #2ea8df;
+  --accent: #f2ba72;
+  --sidebar-bg: #edf2f9;
+  --sidebar-panel: rgba(255, 255, 255, 0.78);
+  --sidebar-border: rgba(102, 123, 152, 0.18);
+  --light-bg: #f7f8fa;
+  --bg-elevated: #ffffff;
+  --hero-bg: #ffffff;
+  --card-bg: #ffffff;
+  --card-strong: #ffffff;
+  --text-primary: #14213d;
+  --text-secondary: #2a3a52;
+  --text-muted: #5f748f;
+  --text-light: #8b9db5;
+  --border-color: rgba(102, 123, 152, 0.18);
+  --hairline: rgba(102, 123, 152, 0.14);
+  --grid-line: rgba(74, 96, 123, 0.08);
+  --shadow-xs: 0 8px 24px rgba(26, 41, 61, 0.06);
+  --shadow-sm: 0 18px 40px rgba(26, 41, 61, 0.08);
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 18px;
+  --transition: all 0.2s ease;
+  --serif-stack: "Source Serif Pro", "Source Serif 4", "Iowan Old Style",
+    "Charter", "Baskerville", Georgia, serif;
+}
+
+.blog-shell.is-dark {
+  --sidebar-bg: #0b1523;
+  --sidebar-panel: rgba(9, 18, 31, 0.78);
+  --sidebar-border: rgba(111, 141, 177, 0.16);
+  --light-bg: #0a131f;
+  --bg-elevated: #0c1727;
+  --hero-bg: #0c1727;
+  --card-bg: #0c1727;
+  --card-strong: #0f1c2f;
+  --text-primary: #eef4ff;
+  --text-secondary: #d6e1f0;
+  --text-muted: #9eb1c8;
+  --text-light: #70839d;
+  --border-color: rgba(111, 141, 177, 0.16);
+  --hairline: rgba(111, 141, 177, 0.14);
+  --grid-line: rgba(120, 145, 178, 0.08);
+}
+
+.blog-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--light-bg);
+  color: var(--text-primary);
+  font-family: "Inter", sans-serif;
+}
+
+.blog-main {
+  flex: 1;
+  width: 100%;
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 56px 24px 80px;
+}
+
+.blog-eyebrow {
+  display: inline-block;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.blog-hero {
+  padding-bottom: 8px;
+  margin-bottom: 32px;
+  border-bottom: 1px solid var(--hairline);
+}
+
+.blog-hero-title {
+  margin: 12px 0 14px;
+  color: var(--text-primary);
+  font-family: "Inter", sans-serif;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  line-height: 1.15;
+  letter-spacing: -0.025em;
+  font-weight: 700;
+}
+
+.blog-hero-lede {
+  margin: 0 0 28px;
+  color: var(--text-secondary);
+  font-family: var(--serif-stack);
+  font-size: 17px;
+  line-height: 1.7;
+  max-width: 56ch;
+}
+
+/* List of posts — plain rows, hairline dividers, no cards. */
+
+.blog-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.blog-row {
+  display: block;
+  padding: 28px 0;
+  border-bottom: 1px solid var(--hairline);
+  text-decoration: none;
+  color: inherit;
+  transition: opacity 0.2s ease;
+}
+
+.blog-row:first-child {
+  padding-top: 8px;
+}
+
+.blog-row:last-child {
+  border-bottom: none;
+}
+
+.blog-row:hover .blog-row-title {
+  color: var(--primary);
+}
+
+.blog-row-meta,
+.blog-article-meta {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  color: var(--text-muted);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+}
+
+.blog-meta-divider {
+  color: var(--text-light);
+}
+
+.blog-row-title {
+  margin: 8px 0 6px;
+  color: var(--text-primary);
+  font-family: "Inter", sans-serif;
+  font-size: 22px;
+  line-height: 1.25;
+  letter-spacing: -0.02em;
+  font-weight: 700;
+  transition: color 0.2s ease;
+}
+
+.blog-row-excerpt {
+  margin: 0;
+  color: var(--text-secondary);
+  font-family: var(--serif-stack);
+  font-size: 16px;
+  line-height: 1.65;
+}
+
+.blog-row-tags,
+.blog-article-tags {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 8px;
+  color: var(--text-light);
+  font-size: 12px;
+  font-style: italic;
+}
+
+.blog-row-tag::before,
+.blog-article-tag::before {
+  content: "·";
+  margin-right: 10px;
+  color: var(--text-light);
+  font-style: normal;
+}
+
+.blog-row-tag:first-child::before,
+.blog-article-tag:first-child::before {
+  content: "";
+  margin-right: 0;
+}
+
+/* Article (single post) */
+
+.blog-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 24px;
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 500;
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.blog-back-link:hover {
+  color: var(--primary);
+  transform: translateX(-2px);
+}
+
+.blog-article {
+  display: flex;
+  flex-direction: column;
+}
+
+.blog-article-header {
+  padding-bottom: 28px;
+  margin-bottom: 32px;
+  border-bottom: 1px solid var(--hairline);
+}
+
+.blog-article-tags {
+  margin-top: 0;
+  margin-bottom: 14px;
+}
+
+.blog-article-title {
+  margin: 0 0 14px;
+  color: var(--text-primary);
+  font-family: "Inter", sans-serif;
+  font-size: clamp(2rem, 4.4vw, 2.8rem);
+  line-height: 1.1;
+  letter-spacing: -0.035em;
+  font-weight: 700;
+}
+
+.blog-article-meta {
+  font-size: 13px;
+}
+
+.blog-article-body {
+  font-family: var(--serif-stack);
+  color: var(--text-primary);
+  font-size: 19px;
+  line-height: 1.78;
+}
+
+.blog-paragraph {
+  margin: 0 0 1.4em;
+  color: var(--text-secondary);
+}
+
+.blog-paragraph:last-child {
+  margin-bottom: 0;
+}
+
+.blog-h2 {
+  font-family: "Inter", sans-serif;
+  margin: 48px 0 16px;
+  color: var(--text-primary);
+  font-size: 22px;
+  letter-spacing: -0.02em;
+  font-weight: 700;
+}
+
+.blog-pullquote {
+  margin: 32px 0;
+  padding: 4px 0 4px 22px;
+  border-left: 3px solid var(--text-primary);
+  color: var(--text-primary);
+  font-family: var(--serif-stack);
+  font-style: italic;
+  font-size: 21px;
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+}
+
+.blog-divider {
+  border: none;
+  border-top: 1px solid var(--hairline);
+  margin: 56px 0 36px;
+}
+
+/* Comments */
+
+.blog-comments {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.blog-comments-heading {
+  margin: 6px 0 0;
+  color: var(--text-primary);
+  font-family: "Inter", sans-serif;
+  font-size: 20px;
+  letter-spacing: -0.015em;
+  font-weight: 700;
+}
+
+.blog-comments-body {
+  margin: 0 0 4px;
+  color: var(--text-secondary);
+  font-family: var(--serif-stack);
+  font-size: 16px;
+  line-height: 1.65;
+}
+
+.blog-comments-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.blog-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-color);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: "Inter", sans-serif;
+  transition: var(--transition);
+}
+
+.blog-shell.is-dark .blog-action {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.blog-action:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+.cusdis-mount {
+  margin-top: 8px;
+}
+
+/* Footer */
+
+.blog-footer {
+  padding: 28px 24px 36px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  border-top: 1px solid var(--hairline);
+}
+
+@media (max-width: 768px) {
+  .blog-main {
+    padding: 32px 18px 56px;
+  }
+
+  .blog-row {
+    padding: 22px 0;
+  }
+
+  .blog-row-title {
+    font-size: 19px;
+  }
+
+  .blog-article-body {
+    font-size: 17px;
+    line-height: 1.75;
+  }
+
+  .blog-pullquote {
+    font-size: 19px;
+  }
+
+  .blog-action {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/src/react-app/components/blog/Blog.css
+++ b/src/react-app/components/blog/Blog.css
@@ -64,7 +64,7 @@
 .blog-main {
   flex: 1;
   width: 100%;
-  max-width: 680px;
+  max-width: 960px;
   margin: 0 auto;
   padding: 56px 24px 80px;
 }

--- a/src/react-app/components/blog/BlogList.js
+++ b/src/react-app/components/blog/BlogList.js
@@ -1,0 +1,78 @@
+import React, { useEffect } from "react";
+import { Link } from "react-router-dom";
+import BlogShell from "./BlogShell";
+import useDarkMode from "../common/useDarkMode";
+import { getAllPosts } from "./posts";
+import { mixpanel } from "../../../App";
+
+const formatDate = (iso) => {
+  try {
+    const date = new Date(iso);
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  } catch (e) {
+    return iso;
+  }
+};
+
+const BlogList = () => {
+  const [darkMode, toggleDarkMode] = useDarkMode();
+  const posts = getAllPosts();
+
+  useEffect(() => {
+    mixpanel.track("Blog List View");
+    window.scrollTo(0, 0);
+  }, []);
+
+  return (
+    <BlogShell darkMode={darkMode} toggleDarkMode={toggleDarkMode}>
+      <section className="blog-hero">
+        <span className="blog-eyebrow">Writing</span>
+        <h1 className="blog-hero-title">
+          Long-form notes on AI, products, and the systems they sit inside.
+        </h1>
+        <p className="blog-hero-lede">
+          A slow-paced shelf of essays. The work is mostly engineering and
+          product, but the questions almost always end up larger than that:
+          where talent goes, how systems concentrate, what stays
+          human-centered when capability stops being the bottleneck.
+        </p>
+      </section>
+
+      <section className="blog-list" aria-label="All posts">
+        {posts.map((post) => (
+          <Link
+            key={post.slug}
+            to={`/blog/${post.slug}`}
+            className="blog-row"
+            onClick={() =>
+              mixpanel.track("Blog Post Click", { post: post.slug })
+            }
+          >
+            <div className="blog-row-meta">
+              <time dateTime={post.date}>{formatDate(post.date)}</time>
+              <span className="blog-meta-divider">·</span>
+              <span>{post.readingTime}</span>
+            </div>
+            <h2 className="blog-row-title">{post.title}</h2>
+            <p className="blog-row-excerpt">{post.excerpt}</p>
+            {post.tags && post.tags.length > 0 ? (
+              <div className="blog-row-tags">
+                {post.tags.map((tag) => (
+                  <span key={tag} className="blog-row-tag">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+          </Link>
+        ))}
+      </section>
+    </BlogShell>
+  );
+};
+
+export default BlogList;

--- a/src/react-app/components/blog/BlogList.js
+++ b/src/react-app/components/blog/BlogList.js
@@ -29,19 +29,6 @@ const BlogList = () => {
 
   return (
     <BlogShell darkMode={darkMode} toggleDarkMode={toggleDarkMode}>
-      <section className="blog-hero">
-        <span className="blog-eyebrow">Writing</span>
-        <h1 className="blog-hero-title">
-          Long-form notes on AI, products, and the systems they sit inside.
-        </h1>
-        <p className="blog-hero-lede">
-          A slow-paced shelf of essays. The work is mostly engineering and
-          product, but the questions almost always end up larger than that:
-          where talent goes, how systems concentrate, what stays
-          human-centered when capability stops being the bottleneck.
-        </p>
-      </section>
-
       <section className="blog-list" aria-label="All posts">
         {posts.map((post) => (
           <Link
@@ -59,15 +46,6 @@ const BlogList = () => {
             </div>
             <h2 className="blog-row-title">{post.title}</h2>
             <p className="blog-row-excerpt">{post.excerpt}</p>
-            {post.tags && post.tags.length > 0 ? (
-              <div className="blog-row-tags">
-                {post.tags.map((tag) => (
-                  <span key={tag} className="blog-row-tag">
-                    {tag}
-                  </span>
-                ))}
-              </div>
-            ) : null}
           </Link>
         ))}
       </section>

--- a/src/react-app/components/blog/BlogPost.js
+++ b/src/react-app/components/blog/BlogPost.js
@@ -97,15 +97,6 @@ const BlogPost = () => {
         </Link>
 
         <header className="blog-article-header">
-          {post.tags && post.tags.length > 0 ? (
-            <div className="blog-article-tags">
-              {post.tags.map((tag) => (
-                <span key={tag} className="blog-article-tag">
-                  {tag}
-                </span>
-              ))}
-            </div>
-          ) : null}
           <h1 className="blog-article-title">{post.title}</h1>
           <div className="blog-article-meta">
             <time dateTime={post.date}>{formatDate(post.date)}</time>

--- a/src/react-app/components/blog/BlogPost.js
+++ b/src/react-app/components/blog/BlogPost.js
@@ -1,0 +1,135 @@
+import React, { useEffect } from "react";
+import { Link, useParams } from "react-router-dom";
+import BlogShell from "./BlogShell";
+import Comments from "./Comments";
+import useDarkMode from "../common/useDarkMode";
+import { getPostBySlug } from "./posts";
+import { mixpanel } from "../../../App";
+
+const formatDate = (iso) => {
+  try {
+    const date = new Date(iso);
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  } catch (e) {
+    return iso;
+  }
+};
+
+const renderBlock = (block, index) => {
+  switch (block.type) {
+    case "pullquote":
+      return (
+        <blockquote key={index} className="blog-pullquote">
+          {block.text}
+        </blockquote>
+      );
+    case "h2":
+      return (
+        <h2 key={index} className="blog-h2">
+          {block.text}
+        </h2>
+      );
+    case "p":
+    default:
+      return (
+        <p key={index} className="blog-paragraph">
+          {block.text}
+        </p>
+      );
+  }
+};
+
+const NotFoundBody = () => (
+  <section className="blog-hero">
+    <span className="blog-eyebrow">Missing</span>
+    <h1 className="blog-hero-title">That essay does not exist yet.</h1>
+    <p className="blog-hero-lede">
+      It might be unpublished, or the URL may have shifted. Head back to the
+      writing shelf and pick another one.
+    </p>
+    <Link
+      to="/blog"
+      className="blog-action"
+      onClick={() => mixpanel.track("Blog Back Click", { post: "missing" })}
+    >
+      <i className="fa fa-arrow-left" aria-hidden="true"></i>
+      Back to all posts
+    </Link>
+  </section>
+);
+
+const BlogPost = () => {
+  const { slug } = useParams();
+  const post = getPostBySlug(slug);
+  const [darkMode, toggleDarkMode] = useDarkMode();
+
+  useEffect(() => {
+    if (post) {
+      mixpanel.track("Blog Post View", { post: post.slug });
+    } else {
+      mixpanel.track("Blog Post Missing", { slug });
+    }
+    window.scrollTo(0, 0);
+  }, [slug, post]);
+
+  if (!post) {
+    return (
+      <BlogShell darkMode={darkMode} toggleDarkMode={toggleDarkMode}>
+        <NotFoundBody />
+      </BlogShell>
+    );
+  }
+
+  return (
+    <BlogShell darkMode={darkMode} toggleDarkMode={toggleDarkMode}>
+      <article className="blog-article">
+        <Link
+          to="/blog"
+          className="blog-back-link"
+          onClick={() => mixpanel.track("Blog Back Click", { post: post.slug })}
+        >
+          <i className="fa fa-arrow-left" aria-hidden="true"></i>
+          Back to writing
+        </Link>
+
+        <header className="blog-article-header">
+          {post.tags && post.tags.length > 0 ? (
+            <div className="blog-article-tags">
+              {post.tags.map((tag) => (
+                <span key={tag} className="blog-article-tag">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          ) : null}
+          <h1 className="blog-article-title">{post.title}</h1>
+          <div className="blog-article-meta">
+            <time dateTime={post.date}>{formatDate(post.date)}</time>
+            <span className="blog-meta-divider">·</span>
+            <span>{post.readingTime}</span>
+            <span className="blog-meta-divider">·</span>
+            <span>By Sharang Pai</span>
+          </div>
+        </header>
+
+        <div className="blog-article-body">
+          {post.content.map((block, index) => renderBlock(block, index))}
+        </div>
+
+        <hr className="blog-divider" />
+
+        <Comments
+          darkMode={darkMode}
+          slug={post.slug}
+          title={post.title}
+        />
+      </article>
+    </BlogShell>
+  );
+};
+
+export default BlogPost;

--- a/src/react-app/components/blog/BlogPost.js
+++ b/src/react-app/components/blog/BlogPost.js
@@ -8,17 +8,19 @@ import { mixpanel } from "../../../App";
 
 const formatDate = (iso) => {
   try {
-    const date = new Date(iso);
-    return date.toLocaleDateString("en-US", {
+    const [year, month, day] = iso.split("T")[0].split("-").map(Number);
+
+    if (!year || !month || !day) return iso;
+
+    return new Intl.DateTimeFormat("en-US", {
       year: "numeric",
       month: "long",
       day: "numeric",
-    });
+    }).format(new Date(year, month - 1, day));
   } catch (e) {
     return iso;
   }
 };
-
 const renderBlock = (block, index) => {
   switch (block.type) {
     case "pullquote":

--- a/src/react-app/components/blog/BlogShell.js
+++ b/src/react-app/components/blog/BlogShell.js
@@ -1,0 +1,19 @@
+import React from "react";
+import SiteTopBar from "../common/SiteTopBar";
+import "./Blog.css";
+
+const BlogShell = ({ children, darkMode, toggleDarkMode }) => {
+  return (
+    <div className={`blog-shell${darkMode ? " is-dark" : ""}`}>
+      <SiteTopBar darkMode={darkMode} toggleDarkMode={toggleDarkMode} />
+
+      <main className="blog-main">{children}</main>
+
+      <footer className="blog-footer">
+        © Sharang Pai
+      </footer>
+    </div>
+  );
+};
+
+export default BlogShell;

--- a/src/react-app/components/blog/BlogShell.js
+++ b/src/react-app/components/blog/BlogShell.js
@@ -8,10 +8,6 @@ const BlogShell = ({ children, darkMode, toggleDarkMode }) => {
       <SiteTopBar darkMode={darkMode} toggleDarkMode={toggleDarkMode} />
 
       <main className="blog-main">{children}</main>
-
-      <footer className="blog-footer">
-        © Sharang Pai
-      </footer>
     </div>
   );
 };

--- a/src/react-app/components/blog/Comments.js
+++ b/src/react-app/components/blog/Comments.js
@@ -1,0 +1,128 @@
+import React, { useEffect, useRef } from "react";
+import commentsConfig, { isCommentsConfigured } from "./comments.config";
+import { mixpanel } from "../../../App";
+
+const SCRIPT_SRC = "https://cusdis.com/js/cusdis.es.js";
+
+const ensureCusdisScript = () => {
+  if (typeof document === "undefined") return;
+  if (document.querySelector(`script[src="${SCRIPT_SRC}"]`)) {
+    if (window.CUSDIS && typeof window.CUSDIS.initial === "function") {
+      window.CUSDIS.initial();
+    }
+    return;
+  }
+  const script = document.createElement("script");
+  script.src = SCRIPT_SRC;
+  script.async = true;
+  script.defer = true;
+  document.body.appendChild(script);
+};
+
+const Comments = ({ darkMode, slug, title }) => {
+  const configured = isCommentsConfigured();
+  const tracked = useRef(false);
+
+  useEffect(() => {
+    if (!configured) return;
+    ensureCusdisScript();
+    if (!tracked.current) {
+      mixpanel.track("Blog Comments Loaded", { post: slug });
+      tracked.current = true;
+    }
+  }, [configured, slug]);
+
+  useEffect(() => {
+    if (!configured) return;
+    if (typeof window === "undefined") return;
+    if (window.CUSDIS && typeof window.CUSDIS.setTheme === "function") {
+      window.CUSDIS.setTheme(darkMode ? "dark" : "light");
+    }
+  }, [darkMode, configured]);
+
+  if (!configured) {
+    const subject = encodeURIComponent(`Re: ${title}`);
+    return (
+      <section className="blog-comments" id="comments">
+        <span className="blog-eyebrow">Discussion</span>
+        <h3 className="blog-comments-heading">
+          Reply, push back, or share a thread.
+        </h3>
+        <p className="blog-comments-body">
+          Open commenting is not wired up yet. If something here landed, or if
+          you disagree, I would genuinely like to hear it.
+        </p>
+        <div className="blog-comments-actions">
+          <a
+            className="blog-action"
+            href={`mailto:sharangpai123@gmail.com?subject=${subject}`}
+            onClick={() =>
+              mixpanel.track("Blog Reply Click", {
+                channel: "email",
+                post: slug,
+              })
+            }
+          >
+            <i className="fa fa-envelope" aria-hidden="true"></i>
+            Reply by email
+          </a>
+          <a
+            className="blog-action"
+            href="https://www.linkedin.com/in/sharang-pai/"
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() =>
+              mixpanel.track("Blog Reply Click", {
+                channel: "linkedin",
+                post: slug,
+              })
+            }
+          >
+            <i className="fa fa-linkedin" aria-hidden="true"></i>
+            Message on LinkedIn
+          </a>
+          <a
+            className="blog-action"
+            href="https://www.github.com/Guzzler"
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() =>
+              mixpanel.track("Blog Reply Click", {
+                channel: "github",
+                post: slug,
+              })
+            }
+          >
+            <i className="fa fa-github" aria-hidden="true"></i>
+            Find me on GitHub
+          </a>
+        </div>
+      </section>
+    );
+  }
+
+  const pageUrl =
+    typeof window !== "undefined" ? window.location.href : `/blog/${slug}`;
+
+  return (
+    <section className="blog-comments" id="comments">
+      <span className="blog-eyebrow">Discussion</span>
+      <h3 className="blog-comments-heading">Comments</h3>
+      <p className="blog-comments-body">
+        Leave a name and a comment. No login, replies welcome.
+      </p>
+      <div
+        id="cusdis_thread"
+        className="cusdis-mount"
+        data-host={commentsConfig.host}
+        data-app-id={commentsConfig.appId}
+        data-page-id={slug}
+        data-page-url={pageUrl}
+        data-page-title={title}
+        data-theme={darkMode ? "dark" : "light"}
+      />
+    </section>
+  );
+};
+
+export default Comments;

--- a/src/react-app/components/blog/Comments.js
+++ b/src/react-app/components/blog/Comments.js
@@ -1,126 +1,68 @@
-import React, { useEffect, useRef } from "react";
-import commentsConfig, { isCommentsConfigured } from "./comments.config";
+import React from "react";
 import { mixpanel } from "../../../App";
 
-const SCRIPT_SRC = "https://cusdis.com/js/cusdis.es.js";
-
-const ensureCusdisScript = () => {
-  if (typeof document === "undefined") return;
-  if (document.querySelector(`script[src="${SCRIPT_SRC}"]`)) {
-    if (window.CUSDIS && typeof window.CUSDIS.initial === "function") {
-      window.CUSDIS.initial();
-    }
-    return;
-  }
-  const script = document.createElement("script");
-  script.src = SCRIPT_SRC;
-  script.async = true;
-  script.defer = true;
-  document.body.appendChild(script);
-};
-
-const Comments = ({ darkMode, slug, title }) => {
-  const configured = isCommentsConfigured();
-  const tracked = useRef(false);
-
-  useEffect(() => {
-    if (!configured) return;
-    ensureCusdisScript();
-    if (!tracked.current) {
-      mixpanel.track("Blog Comments Loaded", { post: slug });
-      tracked.current = true;
-    }
-  }, [configured, slug]);
-
-  useEffect(() => {
-    if (!configured) return;
-    if (typeof window === "undefined") return;
-    if (window.CUSDIS && typeof window.CUSDIS.setTheme === "function") {
-      window.CUSDIS.setTheme(darkMode ? "dark" : "light");
-    }
-  }, [darkMode, configured]);
-
-  if (!configured) {
-    const subject = encodeURIComponent(`Re: ${title}`);
-    return (
-      <section className="blog-comments" id="comments">
-        <span className="blog-eyebrow">Discussion</span>
-        <h3 className="blog-comments-heading">
-          Reply, push back, or share a thread.
-        </h3>
-        <p className="blog-comments-body">
-          Open commenting is not wired up yet. If something here landed, or if
-          you disagree, I would genuinely like to hear it.
-        </p>
-        <div className="blog-comments-actions">
-          <a
-            className="blog-action"
-            href={`mailto:sharangpai123@gmail.com?subject=${subject}`}
-            onClick={() =>
-              mixpanel.track("Blog Reply Click", {
-                channel: "email",
-                post: slug,
-              })
-            }
-          >
-            <i className="fa fa-envelope" aria-hidden="true"></i>
-            Reply by email
-          </a>
-          <a
-            className="blog-action"
-            href="https://www.linkedin.com/in/sharang-pai/"
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() =>
-              mixpanel.track("Blog Reply Click", {
-                channel: "linkedin",
-                post: slug,
-              })
-            }
-          >
-            <i className="fa fa-linkedin" aria-hidden="true"></i>
-            Message on LinkedIn
-          </a>
-          <a
-            className="blog-action"
-            href="https://www.github.com/Guzzler"
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() =>
-              mixpanel.track("Blog Reply Click", {
-                channel: "github",
-                post: slug,
-              })
-            }
-          >
-            <i className="fa fa-github" aria-hidden="true"></i>
-            Find me on GitHub
-          </a>
-        </div>
-      </section>
-    );
-  }
-
-  const pageUrl =
-    typeof window !== "undefined" ? window.location.href : `/blog/${slug}`;
+const Comments = ({ slug, title }) => {
+  const subject = encodeURIComponent(`Re: ${title}`);
 
   return (
     <section className="blog-comments" id="comments">
       <span className="blog-eyebrow">Discussion</span>
-      <h3 className="blog-comments-heading">Comments</h3>
+      <h3 className="blog-comments-heading">
+        Reply, push back, or share a thread.
+      </h3>
       <p className="blog-comments-body">
-        Leave a name and a comment. No login, replies welcome.
+        I’m not running an open comment box here because I’d rather keep the
+        discussion personal and spam-free. If something here landed, or if you
+        disagree, I would genuinely like to hear it.
       </p>
-      <div
-        id="cusdis_thread"
-        className="cusdis-mount"
-        data-host={commentsConfig.host}
-        data-app-id={commentsConfig.appId}
-        data-page-id={slug}
-        data-page-url={pageUrl}
-        data-page-title={title}
-        data-theme={darkMode ? "dark" : "light"}
-      />
+
+      <div className="blog-comments-actions">
+        <a
+          className="blog-action"
+          href={`mailto:sharangpai123@gmail.com?subject=${subject}`}
+          onClick={() =>
+            mixpanel.track("Blog Reply Click", {
+              channel: "email",
+              post: slug,
+            })
+          }
+        >
+          <i className="fa fa-envelope" aria-hidden="true"></i>
+          Reply by email
+        </a>
+
+        <a
+          className="blog-action"
+          href="https://www.linkedin.com/in/sharang-pai/"
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() =>
+            mixpanel.track("Blog Reply Click", {
+              channel: "linkedin",
+              post: slug,
+            })
+          }
+        >
+          <i className="fa fa-linkedin" aria-hidden="true"></i>
+          Message on LinkedIn
+        </a>
+
+        <a
+          className="blog-action"
+          href="https://www.github.com/Guzzler"
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() =>
+            mixpanel.track("Blog Reply Click", {
+              channel: "github",
+              post: slug,
+            })
+          }
+        >
+          <i className="fa fa-github" aria-hidden="true"></i>
+          Find me on GitHub
+        </a>
+      </div>
     </section>
   );
 };

--- a/src/react-app/components/blog/comments.config.js
+++ b/src/react-app/components/blog/comments.config.js
@@ -1,0 +1,17 @@
+// Cusdis comments configuration.
+//
+// Cusdis (https://cusdis.com) is a lightweight, open-source comment system.
+// Visitors leave a name + comment (no login). Replies are threaded.
+// Moderation happens from the dashboard at https://cusdis.com.
+//
+// To self-host or move dashboards later, change `host` and `appId` here.
+
+const commentsConfig = {
+  host: "https://cusdis.com",
+  appId: "b1c3a665-6eba-4202-920f-841e4dd810bc",
+};
+
+export const isCommentsConfigured = () =>
+  Boolean(commentsConfig.host && commentsConfig.appId);
+
+export default commentsConfig;

--- a/src/react-app/components/blog/posts/index.js
+++ b/src/react-app/components/blog/posts/index.js
@@ -1,0 +1,12 @@
+import immigrantsDilemma from "./the-immigrants-dilemma";
+
+const posts = [immigrantsDilemma];
+
+const sortedPosts = [...posts].sort((a, b) => (a.date < b.date ? 1 : -1));
+
+export const getAllPosts = () => sortedPosts;
+
+export const getPostBySlug = (slug) =>
+  sortedPosts.find((post) => post.slug === slug);
+
+export default sortedPosts;

--- a/src/react-app/components/blog/posts/the-immigrants-dilemma.js
+++ b/src/react-app/components/blog/posts/the-immigrants-dilemma.js
@@ -1,0 +1,145 @@
+const post = {
+  slug: "the-immigrants-dilemma",
+  title: "The Immigrant's Dilemma",
+  date: "2026-04-26",
+  readingTime: "10 min read",
+  tags: ["Essay", "AI", "Game theory"],
+  excerpt:
+    "What makes sense for an individual and what might be good for the world are not always the same thing. And increasingly, in a world being shaped by AI, they feel pulled in different directions.",
+  content: [
+    {
+      type: "p",
+      text: "Lately I have been thinking a lot about a version of the prisoner's dilemma that feels very personal to me.",
+    },
+    {
+      type: "p",
+      text: "On paper, my life is moving in a direction that feels completely rational. I work in AI in the United States. I am close to ambitious systems, strong institutions, smart people, and the kind of environment where things move fast and compound. I get to work on hard problems with real product depth. It is exciting, and I would be lying if I said I do not enjoy being close to that energy. There is something intoxicating about being in places where ambition is normal and technical seriousness is assumed. It changes your standards. It changes your sense of what is possible.",
+    },
+    {
+      type: "p",
+      text: "At the same time, I keep returning to a more uncomfortable thought. What if the choice that is rational for me is also part of what makes the world worse?",
+    },
+    {
+      type: "p",
+      text: "I do not mean that in a dramatic or moralistic way. I do not mean that personal ambition is bad, or that building in the United States is somehow a betrayal. I also do not think the answer is as simple as saying people should just go back home and build there. That kind of language has always felt too easy to me. The real problem is more difficult than that.",
+    },
+    {
+      type: "p",
+      text: "The problem is that what makes sense for an individual and what might be good for the world are not always the same thing. And this feels more urgent to me now because AI does not seem like just another industry. We may be moving even deeper into a world where a small number of companies and countries shape the most powerful systems, capture a disproportionate amount of the wealth they create, and set the norms the rest of the world adapts to. If that is true, then where talent goes starts to matter differently.",
+    },
+    { type: "p", text: "That is what made me think of Axelrod." },
+    {
+      type: "p",
+      text: "The basic prisoner's dilemma is simple enough to explain to a child. Two people each have a choice. They can cooperate, or they can defect. If both cooperate, both do reasonably well. If one defects while the other cooperates, the defector gets more and the cooperator loses. If both defect, both end up worse off. The strange part is that defection can look like the smart move for each person even though it leads to a worse outcome when everyone does it.",
+    },
+    {
+      type: "p",
+      text: "What Axelrod added was the idea of repetition. Real life is not one move. It is many rounds: memory, reputation, retaliation, forgiveness, and the slow discovery of what kind of world you are in. And repetition changes the logic of the game. In a one-shot prisoner's dilemma, defection dominates. In a repeated one, cooperation can become rational because today's move affects tomorrow's response. But that stability is fragile. If both players know there is a final round, then defection starts to look attractive at the end, which can unravel trust one step earlier, and then earlier still. In other words, cooperation is not just about virtue. It depends on whether the game is structured in a way that lets cooperation survive.",
+    },
+    { type: "p", text: "That is the part that stays with me." },
+    {
+      type: "pullquote",
+      text: "Cooperation is not just a virtue. It depends on the structure of the game.",
+    },
+    {
+      type: "p",
+      text: "And increasingly, the game I feel myself inside is this. For someone like me, staying close to the dominant center of AI is the rational move. The ecosystem is stronger. The density of people is higher. The capital is here. The infrastructure is here. The feedback loops are tighter. If I want to become sharper, stronger, and more capable, it makes sense to stay where all of that exists. It does not feel like a compromised choice. It feels like the obvious one.",
+    },
+    {
+      type: "p",
+      text: "But if enough people like me keep making that same obvious choice, then the collective result starts to look different.",
+    },
+    {
+      type: "p",
+      text: "We do not just send talent toward opportunity. We also help decide where the future gets built. Where talent clusters affects where institutions mature, where capital gets recycled, where research agendas get set, and who develops the confidence to build foundational systems instead of adapting to them later. In an AI-heavy world, this feels even more important. If intelligence itself becomes one of the main drivers of economic and political leverage, then the places that dominate AI will not just build better products. They will shape the distribution of wealth, power, and autonomy for everyone else.",
+    },
+    {
+      type: "p",
+      text: "That is where this starts to feel like more than a career choice.",
+    },
+    {
+      type: "p",
+      text: "A lot of the projects I have cared most about in my life came from a very different instinct. OpenShiksha was about education access. VaccinePost came from a moment when a lot of people in India were locked out by bad design, weak interfaces, and low technical literacy in a crisis. Even a lot of the public-interest and low-resource work I have been drawn to comes from the same basic belief. Technology should not just make impressive things for people who are already close to power. It should widen access. It should help people who are usually treated like edge cases. It should matter outside the usual demo loop.",
+    },
+    {
+      type: "p",
+      text: "That instinct is still very real in me. It is not something I have grown out of. If anything, it has become more important as I have spent more time in AI.",
+    },
+    {
+      type: "p",
+      text: "But so has the other instinct. The one that wants to build where the sharpest people are. The one that wants to be inside environments that make you better. The one that knows how much easier it is to move quickly when you are surrounded by the right infrastructure, the right capital, and the right kinds of peers.",
+    },
+    {
+      type: "p",
+      text: "Part of what makes this difficult is that India is not an abstraction to me. It is where my family is. It is where I grew up. It shaped my instincts long before I had any language for ambition, technology, or leverage. So when I think about building there, or returning in some meaningful sense, I am not thinking only about markets or ecosystems. I am also thinking about belonging, familiarity, and the place that formed me. That emotional connection is real. But I also do not know if it is enough.",
+    },
+    {
+      type: "p",
+      text: "As the stakes get larger, I keep coming back to a harder question. How much weight should emotion carry in a decision like this if the structural reality is pushing so strongly in another direction? If the future is going to be shaped by concentration of capital, compute, institutions, and technical power, does love for a place meaningfully change the decision, or does it just make the tradeoff hurt more?",
+    },
+    {
+      type: "p",
+      text: "That is why this does not feel like a normal immigration story to me. India is the place where the dilemma becomes emotionally real, but the structure of the problem is larger than India itself. It is about concentration. If the individually rational move for enough talented people is to join the same few hubs, those hubs become even more powerful, more self-reinforcing, and more capable of shaping the future in their own image. That is the tension as I feel it. It is not a simple choice between selfishness and goodness, or between America and India. It is a tension between two levels of rationality. One asks where I can do the best work of my life. The other asks what kind of world gets created if enough people like me answer that question in the same way.",
+    },
+    {
+      type: "p",
+      text: "At the same time, I do not think the counterpoint can be romanticized. I have spoken to people who went back and later returned. I have spoken to people who wanted to go back and could not convince themselves that it made sense. I have heard enough versions of that story that it no longer feels abstract to me, though I also know there is some sampling bias in that, since many of those people are people I met in the US and are therefore more likely to narrate disappointment than possibility. Even so, the pattern is hard to dismiss. They talk about funding being much harder, institutions being less reliable, and the surrounding talent graph feeling more fragmented. They talk about corruption, bureaucracy, and the general chaos of things wearing them down in ways that are difficult to explain unless you have lived inside that friction.",
+    },
+    {
+      type: "p",
+      text: "And yet I do not think that friction tells the whole story. There are also people who have managed to build meaningful things in India, and those stories matter to me too. Not because they make the problem disappear, but because they clarify what the problem actually is. The issue is not talent. It is not ambition. It is not some absence of seriousness. It is whether the surrounding environment can consistently recognize, support, and compound good work. The existence of those counterexamples does not make the drag unreal. It makes the structural question sharper. It suggests that what is scarce is not ability, but the set of conditions that lets ability turn into momentum.",
+    },
+    {
+      type: "p",
+      text: "And in the context of AI, that fear feels even sharper. The issue is not that India lacks talent. It obviously does not. The issue is whether the surrounding ecosystem is prepared for a world where progress compounds around concentrated compute, capital, research depth, and institutional confidence. That matters in any industry, but it matters especially in AI, where small advantages can compound quickly and where the winners may end up with an outsized share of both wealth and influence. The people I have spoken to do not describe a lack of intelligence or ambition. They describe drag. They describe how much harder it is to turn effort into momentum. They describe the feeling of building against the grain just as the grain itself is becoming more important.",
+    },
+    {
+      type: "p",
+      text: "I carry those conversations with me because they make it harder to pretend that the cooperative choice is simply the brave one. Sometimes it is just the more punishing one.",
+    },
+    {
+      type: "p",
+      text: "That is where Axelrod starts to feel less like a clever analogy and more like an honest frame for the problem. Cooperation can survive, but not because people are pure-hearted. It survives when the environment allows it, when cooperation can be recognized, reciprocated, and not immediately crushed by more extractive strategies.",
+    },
+    {
+      type: "p",
+      text: "That is what I keep wondering about in my own life. What does cooperation even mean here?",
+    },
+    {
+      type: "p",
+      text: "I do not think it can simply mean going back to India. That is too crude, and it lets the rest of the world off too easily. Cooperation, in this setting, probably means something broader. It means helping build a world where technological capability is more distributed before concentration hardens even further. It means creating more than one serious center of power. It means directing labor, capital, mentorship, conviction, and long-term energy toward places that might otherwise be left as consumers of the future rather than authors of it.",
+    },
+    {
+      type: "p",
+      text: "Defection, then, is not immigration itself. It is not wanting success. It is not being ambitious. It is choosing the individually rewarding path in a way that simply deepens concentration because concentration is where the rewards already are.",
+    },
+    {
+      type: "p",
+      text: "I do not actually know what I owe the world here. I know what is rational for me in the short and medium term. I know what kinds of environments have made me better. I know how much I still want to work on ambitious systems and difficult products. But I also know that if enough people like me keep moving toward the same centers of gravity, those centers will continue to absorb a disproportionate share of the future.",
+    },
+    {
+      type: "p",
+      text: "There is a version of me that wants to stay close to the frontier for as long as possible. That part of me wants to learn from the best environments, absorb everything I can, build at a high level, and not apologize for wanting to be where things are happening.",
+    },
+    {
+      type: "p",
+      text: "There is another version of me that cannot stop thinking about what happens when all of the talent, ambition, and institutional confidence of the world keep collecting in the same few places. That part of me still believes, maybe stubbornly, that technology should not only deepen the power of already dominant ecosystems. I do not think either side is fake. That is what makes the dilemma real.",
+    },
+    {
+      type: "p",
+      text: "Maybe the hardest part is that the cooperative move in a defector-heavy world can look very similar to self-sabotage. That is not a comfortable thing to admit, but I think it is true. We praise people for building in hard places, for trying to widen the map, for resisting concentration. But praise is not the same thing as support. Admiration is not the same thing as infrastructure.",
+    },
+    {
+      type: "p",
+      text: "So the question, at least for me, is not whether cooperation is morally beautiful. The question is what conditions would make it stable. What would have to change for building serious technology in India to feel less like a lonely gamble and less like stepping away from compounding itself? What kinds of capital, communities, institutions, and bridges would have to exist for that choice to become more viable?",
+    },
+    {
+      type: "p",
+      text: "I do not have clean answers to those questions. I do not even have a clean answer for my own life.",
+    },
+    { type: "p", text: "I am still trying to figure that out." },
+    { type: "p", text: "I hope there are more people dealing with this." },
+  ],
+};
+
+export default post;

--- a/src/react-app/components/blog/posts/the-immigrants-dilemma.js
+++ b/src/react-app/components/blog/posts/the-immigrants-dilemma.js
@@ -2,7 +2,7 @@ const post = {
   slug: "the-immigrants-dilemma",
   title: "The Immigrant's Dilemma",
   date: "2026-04-26",
-  readingTime: "10 min read",
+  readingTime: "7 min read",
   tags: ["Essay", "AI", "Game theory"],
   excerpt:
     "What makes sense for an individual and what might be good for the world are not always the same thing. And increasingly, in a world being shaped by AI, they feel pulled in different directions.",

--- a/src/react-app/components/common/SiteTopBar.css
+++ b/src/react-app/components/common/SiteTopBar.css
@@ -22,7 +22,7 @@
   margin: 0 auto;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: 16px;
   padding: 14px 32px;
 }

--- a/src/react-app/components/common/SiteTopBar.css
+++ b/src/react-app/components/common/SiteTopBar.css
@@ -1,0 +1,109 @@
+/*
+ * Site-wide top bar. Reuses the design tokens defined in BaseContent.css
+ * and Blog.css (--text-primary, --text-muted, --border-color, etc.).
+ * Intentionally restrained: hairline border, no glow, no backdrop blur.
+ */
+
+.site-topbar {
+  position: relative;
+  z-index: 30;
+  width: 100%;
+  background: var(--bg-elevated, #ffffff);
+  border-bottom: 1px solid var(--border-color, rgba(102, 123, 152, 0.18));
+  font-family: "Inter", sans-serif;
+}
+
+.site-topbar.is-dark {
+  background: var(--bg-elevated, #0c1727);
+}
+
+.site-topbar-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 32px;
+}
+
+.site-topbar-brand {
+  color: var(--text-primary, #162338);
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  transition: color 0.2s ease;
+}
+
+.site-topbar-brand:hover {
+  color: var(--primary, #58c7ff);
+}
+
+.site-topbar-nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.site-topbar-link {
+  display: inline-flex;
+  align-items: center;
+  height: 34px;
+  padding: 0 12px;
+  border-radius: 8px;
+  color: var(--text-muted, #5f748f);
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 500;
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.site-topbar-link:hover {
+  color: var(--text-primary, #162338);
+  background: rgba(102, 123, 152, 0.08);
+}
+
+.site-topbar-link.is-active {
+  color: var(--text-primary, #162338);
+  font-weight: 600;
+}
+
+.site-topbar-theme {
+  margin-left: 6px;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted, #5f748f);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.site-topbar-theme:hover {
+  color: var(--text-primary, #162338);
+  background: rgba(102, 123, 152, 0.08);
+}
+
+.site-topbar-theme:focus-visible,
+.site-topbar-link:focus-visible,
+.site-topbar-brand:focus-visible {
+  outline: 2px solid var(--primary, #58c7ff);
+  outline-offset: 2px;
+}
+
+@media (max-width: 768px) {
+  .site-topbar-inner {
+    padding: 12px 16px;
+  }
+
+  .site-topbar-link {
+    padding: 0 10px;
+    font-size: 12px;
+  }
+}

--- a/src/react-app/components/common/SiteTopBar.js
+++ b/src/react-app/components/common/SiteTopBar.js
@@ -1,0 +1,59 @@
+import React from "react";
+import { Link, useLocation } from "react-router-dom";
+import { mixpanel } from "../../../App";
+import "./SiteTopBar.css";
+
+const isHome = (pathname) => pathname === "/" || pathname === "";
+const isBlog = (pathname) =>
+  pathname === "/blog" || pathname.startsWith("/blog/");
+
+const SiteTopBar = ({ darkMode, toggleDarkMode }) => {
+  const { pathname } = useLocation();
+
+  const trackNav = (target) =>
+    mixpanel.track("Site Nav Click", { target });
+
+  return (
+    <header className={`site-topbar${darkMode ? " is-dark" : ""}`}>
+      <div className="site-topbar-inner">
+        <Link
+          to="/"
+          className="site-topbar-brand"
+          onClick={() => trackNav("brand")}
+        >
+          Sharang Pai
+        </Link>
+
+        <nav className="site-topbar-nav" aria-label="Primary">
+          <Link
+            to="/"
+            className={`site-topbar-link${isHome(pathname) ? " is-active" : ""}`}
+            onClick={() => trackNav("home")}
+          >
+            Home
+          </Link>
+          <Link
+            to="/blog"
+            className={`site-topbar-link${isBlog(pathname) ? " is-active" : ""}`}
+            onClick={() => trackNav("blog")}
+          >
+            Writing
+          </Link>
+          <button
+            type="button"
+            className="site-topbar-theme"
+            onClick={toggleDarkMode}
+            aria-label={darkMode ? "Switch to light mode" : "Switch to dark mode"}
+          >
+            <i
+              className={`fa ${darkMode ? "fa-sun" : "fa-moon"}`}
+              aria-hidden="true"
+            ></i>
+          </button>
+        </nav>
+      </div>
+    </header>
+  );
+};
+
+export default SiteTopBar;

--- a/src/react-app/components/common/SiteTopBar.js
+++ b/src/react-app/components/common/SiteTopBar.js
@@ -16,14 +16,6 @@ const SiteTopBar = ({ darkMode, toggleDarkMode }) => {
   return (
     <header className={`site-topbar${darkMode ? " is-dark" : ""}`}>
       <div className="site-topbar-inner">
-        <Link
-          to="/"
-          className="site-topbar-brand"
-          onClick={() => trackNav("brand")}
-        >
-          Sharang Pai
-        </Link>
-
         <nav className="site-topbar-nav" aria-label="Primary">
           <Link
             to="/"

--- a/src/react-app/components/common/useDarkMode.js
+++ b/src/react-app/components/common/useDarkMode.js
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useState } from "react";
+import { mixpanel } from "../../../App";
+
+const STORAGE_KEY = "sp:dark-mode";
+
+const readInitial = () => {
+  if (typeof window === "undefined") return true;
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored === null) return true;
+    return stored === "true";
+  } catch (e) {
+    return true;
+  }
+};
+
+const useDarkMode = () => {
+  const [darkMode, setDarkMode] = useState(readInitial);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, String(darkMode));
+    } catch (e) {
+      /* localStorage unavailable; ignore */
+    }
+  }, [darkMode]);
+
+  const toggleDarkMode = useCallback(() => {
+    setDarkMode((prev) => {
+      const next = !prev;
+      mixpanel.track("Dark Mode Toggle", { mode: next ? "dark" : "light" });
+      return next;
+    });
+  }, []);
+
+  return [darkMode, toggleDarkMode, setDarkMode];
+};
+
+export default useDarkMode;

--- a/src/react-app/components/main-content/BaseContent.css
+++ b/src/react-app/components/main-content/BaseContent.css
@@ -302,12 +302,75 @@
 .home-shell {
   display: flex;
   flex-direction: column;
+  width: 100%;
   min-height: 100vh;
   background: var(--light-bg);
+  overflow-x: hidden;
+}
+
+.home-shell > .ant-row {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+  width: 100%;
 }
 
 .home-shell .left-column {
   min-height: calc(100vh - 60px);
+}
+
+/* Modern scrollbars — apply across the site so the home main column
+   and the blog scroll container both feel quiet rather than chunky. */
+
+.home-shell *::-webkit-scrollbar,
+.blog-shell *::-webkit-scrollbar,
+html::-webkit-scrollbar,
+body::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.home-shell *::-webkit-scrollbar-track,
+.blog-shell *::-webkit-scrollbar-track,
+html::-webkit-scrollbar-track,
+body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.home-shell *::-webkit-scrollbar-thumb,
+.blog-shell *::-webkit-scrollbar-thumb,
+html::-webkit-scrollbar-thumb,
+body::-webkit-scrollbar-thumb {
+  background: rgba(102, 123, 152, 0.28);
+  border-radius: 999px;
+}
+
+.home-shell *::-webkit-scrollbar-thumb:hover,
+.blog-shell *::-webkit-scrollbar-thumb:hover,
+html::-webkit-scrollbar-thumb:hover,
+body::-webkit-scrollbar-thumb:hover {
+  background: rgba(102, 123, 152, 0.45);
+}
+
+.home-shell.dark-mode *::-webkit-scrollbar-thumb,
+.blog-shell.is-dark *::-webkit-scrollbar-thumb {
+  background: rgba(111, 141, 177, 0.22);
+}
+
+.home-shell.dark-mode *::-webkit-scrollbar-thumb:hover,
+.blog-shell.is-dark *::-webkit-scrollbar-thumb:hover {
+  background: rgba(111, 141, 177, 0.4);
+}
+
+/* Firefox */
+.home-shell,
+.blog-shell {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(102, 123, 152, 0.32) transparent;
+}
+
+.home-shell.dark-mode,
+.blog-shell.is-dark {
+  scrollbar-color: rgba(111, 141, 177, 0.28) transparent;
 }
 
 .control-room-hero {

--- a/src/react-app/components/main-content/BaseContent.css
+++ b/src/react-app/components/main-content/BaseContent.css
@@ -299,29 +299,15 @@
   box-shadow: var(--shadow-sm);
 }
 
-.dark-mode-toggle {
-  position: absolute;
-  top: 18px;
-  right: 18px;
-  width: 40px;
-  height: 40px;
-  border-radius: 999px;
-  background: var(--sidebar-panel);
-  border: 1px solid var(--border-color);
-  color: var(--text-muted);
-  cursor: pointer;
+.home-shell {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 16px;
-  box-shadow: var(--shadow-xs);
-  transition: var(--transition);
-  z-index: 10;
+  flex-direction: column;
+  min-height: 100vh;
+  background: var(--light-bg);
 }
 
-.dark-mode-toggle:hover {
-  color: var(--primary);
-  border-color: rgba(88, 199, 255, 0.28);
+.home-shell .left-column {
+  min-height: calc(100vh - 60px);
 }
 
 .control-room-hero {

--- a/src/react-app/components/main-content/BaseContent.js
+++ b/src/react-app/components/main-content/BaseContent.js
@@ -328,13 +328,6 @@ const BaseContent = () => {
                   >
                     View experience
                   </a>
-                  <Link
-                    className="intro-action"
-                    to="/blog"
-                    onClick={() => trackIntroAction("writing")}
-                  >
-                    Read writing
-                  </Link>
                   <a
                     className="intro-action"
                     href="#games"

--- a/src/react-app/components/main-content/BaseContent.js
+++ b/src/react-app/components/main-content/BaseContent.js
@@ -8,6 +8,8 @@ import ExperienceTimeline from "./ExperienceTimeline";
 import { isSmallDevice } from "../../../common/utils/index";
 import sharangPortrait from "../../../assets/images/sharang.jpeg";
 import GameGallery from "./GameGallery";
+import SiteTopBar from "../common/SiteTopBar";
+import useDarkMode from "../common/useDarkMode";
 import { mixpanel } from "../../../App";
 
 const profileSignals = [
@@ -110,7 +112,7 @@ const hobbies = [
 
 const BaseContent = () => {
   const [loaded, setLoaded] = useState(false);
-  const [darkMode, setDarkMode] = useState(true);
+  const [darkMode, toggleDarkMode] = useDarkMode();
   const smallDevice = isSmallDevice();
 
   useEffect(() => {
@@ -119,13 +121,6 @@ const BaseContent = () => {
     img.onload = () => setLoaded(true);
     img.onerror = () => setLoaded(true);
   }, []);
-
-  const toggleDarkMode = () => {
-    setDarkMode(!darkMode);
-    mixpanel.track("Dark Mode Toggle", {
-      mode: !darkMode ? "dark" : "light",
-    });
-  };
 
   const trackSocialClick = (platform) => {
     mixpanel.track("Social Link Click", { platform });
@@ -147,7 +142,9 @@ const BaseContent = () => {
   }
 
   return (
-    <Row className={`width-100 height-min-100 ${darkMode ? "dark-mode" : ""}`}>
+    <div className={`home-shell${darkMode ? " dark-mode" : ""}`}>
+      <SiteTopBar darkMode={darkMode} toggleDarkMode={toggleDarkMode} />
+      <Row className="width-100 height-min-100">
       <Col
         span={4}
         md={8}
@@ -157,14 +154,6 @@ const BaseContent = () => {
         xxl={4}
         className="left-column inter-font"
       >
-        <button
-          className="dark-mode-toggle"
-          onClick={toggleDarkMode}
-          aria-label="Toggle dark mode"
-        >
-          <i className={`fa ${darkMode ? "fa-sun" : "fa-moon"}`}></i>
-        </button>
-
         <div className="profile-rail">
           <div className="loading-screen">
             <div className="portrait-wrapper">
@@ -274,7 +263,11 @@ const BaseContent = () => {
         sm={24}
         xs={24}
         className="resume-main-content inter-font"
-        style={smallDevice ? { minHeight: "100vh" } : { height: "100vh" }}
+        style={
+          smallDevice
+            ? { minHeight: "calc(100vh - 60px)" }
+            : { height: "calc(100vh - 60px)" }
+        }
       >
         <div className="resume-content-shell">
           <header className="control-room-hero" id="top">
@@ -335,6 +328,13 @@ const BaseContent = () => {
                   >
                     View experience
                   </a>
+                  <Link
+                    className="intro-action"
+                    to="/blog"
+                    onClick={() => trackIntroAction("writing")}
+                  >
+                    Read writing
+                  </Link>
                   <a
                     className="intro-action"
                     href="#games"
@@ -567,7 +567,8 @@ const BaseContent = () => {
           {!smallDevice ? <GameGallery /> : null}
         </div>
       </Col>
-    </Row>
+      </Row>
+    </div>
   );
 };
 

--- a/src/react-app/components/main-content/GameGallery.js
+++ b/src/react-app/components/main-content/GameGallery.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import Slider from "react-slick";
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
@@ -87,6 +87,8 @@ const settings = {
   arrows: true,
   autoplaySpeed: 3000,
   autoplay: true,
+  pauseOnHover: true,
+  pauseOnFocus: true,
   slidesToScroll: 1,
   slidesToShow: 3,
   responsive: [
@@ -111,8 +113,45 @@ const settings = {
 };
 
 const GameGallery = () => {
+  const sliderRef = useRef(null);
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [activeGame, setActiveGame] = useState(null);
+
+  useEffect(() => {
+    const gallery = document.getElementById("games");
+    let autoplayTimer;
+
+    // Pause immediately so it stays on your newest game at first.
+    if (sliderRef.current) {
+      sliderRef.current.slickPause();
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          autoplayTimer = setTimeout(() => {
+            if (sliderRef.current) {
+              sliderRef.current.slickPlay();
+            }
+          }, 2000);
+
+          observer.disconnect();
+        }
+      },
+      {
+        threshold: 0.35,
+      }
+    );
+
+    if (gallery) {
+      observer.observe(gallery);
+    }
+
+    return () => {
+      clearTimeout(autoplayTimer);
+      observer.disconnect();
+    };
+  }, []);
 
   const closeModal = useCallback(() => {
     if (activeGame) {
@@ -120,6 +159,7 @@ const GameGallery = () => {
         game_name: activeGame.title,
       });
     }
+
     setIsModalVisible(false);
     setActiveGame(null);
   }, [activeGame]);
@@ -169,7 +209,7 @@ const GameGallery = () => {
         </p>
       </div>
 
-      <Slider {...settings}>
+      <Slider ref={sliderRef} {...settings}>
         {games.map((game) => (
           <div key={game.title} className="game-slide">
             <div
@@ -180,19 +220,32 @@ const GameGallery = () => {
               tabIndex={0}
               aria-label={`${isMobile ? "Open" : "Launch"} ${game.title}`}
             >
-              <img src={game.thumbnail} alt={game.title} className="game-thumbnail" />
+              <img
+                src={game.thumbnail}
+                alt={game.title}
+                className="game-thumbnail"
+              />
+
               <div className="game-info">
                 <div className="game-meta">
                   <span className="game-pill">{game.technologies}</span>
-                  <span className="game-pill game-pill-muted">{game.releaseDate}</span>
+                  <span className="game-pill game-pill-muted">
+                    {game.releaseDate}
+                  </span>
                 </div>
+
                 <h3>{game.title}</h3>
+
                 <p className="game-description">{game.description}</p>
+
                 <span className="play-button">
                   {isMobile ? "Open on itch.io" : "Launch demo"}
                 </span>
+
                 {isMobile ? (
-                  <p className="mobile-hint">Best experienced on desktop when possible</p>
+                  <p className="mobile-hint">
+                    Best experienced on desktop when possible
+                  </p>
                 ) : null}
               </div>
             </div>
@@ -202,10 +255,18 @@ const GameGallery = () => {
 
       {isModalVisible ? (
         <div className="custom-modal-overlay" onClick={closeModal}>
-          <div className="custom-modal" onClick={(event) => event.stopPropagation()}>
-            <button className="close-button" onClick={closeModal} aria-label="Close game">
+          <div
+            className="custom-modal"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <button
+              className="close-button"
+              onClick={closeModal}
+              aria-label="Close game"
+            >
               &times;
             </button>
+
             {activeGame ? (
               <iframe
                 src={activeGame.embedUrl}


### PR DESCRIPTION
## Summary

- Adds a new writing section at `/blog` and a single-post route at `/blog/:slug`, starting with the essay **The Immigrant's Dilemma** (10 min read).
- Introduces a site-wide `SiteTopBar` (Sharang Pai · Home · Writing · theme toggle) shared by the home page and the blog. Replaces the floating dark-mode toggle that lived in the home sidebar.
- Adds a shared `useDarkMode` hook that persists theme preference in `localStorage` so it survives navigation between routes.
- Wires Cusdis-powered comments (no login required, replies threaded, lightweight script). When the configured `appId` isn't reachable, the page falls back to email / LinkedIn / GitHub reply CTAs.
- Mixpanel events fire on every blog interaction: list view, post click, post view, missing-post, nav click, back-link click, dark-mode toggle, reply channel click, comments-loaded.

## Files of note

- `src/react-app/components/blog/` — list, post, comments, post data, styling
- `src/react-app/components/common/SiteTopBar.{js,css}` and `useDarkMode.js` — shared shell
- `src/react-app/components/main-content/BaseContent.{js,css}` — uses the topbar; floating toggle removed
- `public/index.html` — adds Source Serif Pro for body type
- `src/react-app/components/blog/comments.config.js` — Cusdis app ID baked in; swap host/appId here to move dashboards or self-host

## Test plan

- [ ] `/` renders with the new top bar and the existing home content intact; theme toggle works
- [ ] `/blog` shows the writing index as a clean list with hairline dividers (no card chrome)
- [ ] `/blog/the-immigrants-dilemma` renders the essay with serif body, simple pull-quote, and `10 min read` in the metadata
- [ ] Cusdis comment box loads under the essay; theme switches with the topbar toggle
- [ ] Mixpanel events fire (verifiable in DevTools network tab when `REACT_APP_MIXPANEL_TOKEN` is set)
- [ ] Dark/light preference persists across refresh and across `/` ↔ `/blog`

🤖 Generated with [Claude Code](https://claude.com/claude-code)